### PR TITLE
Fix: json tag error in FileInfo

### DIFF
--- a/rpc/resp.go
+++ b/rpc/resp.go
@@ -46,7 +46,7 @@ type FileInfo struct {
 	Index           string    `json:"index"`     // Index of the file, starting at 1, in the same order as files appear in the multi-file torrent.
 	Path            string    `json:"path"`      // File path.
 	Length          string    `json:"length"`    // File size in bytes.
-	CompletedLength string    `json:"completed"` // Completed length of this file in bytes. Please note that it is possible that sum of completedLength is less than the completedLength returned by the aria2.tellStatus() method. This is because completedLength in aria2.getFiles() only includes completed pieces. On the other hand, completedLength in aria2.tellStatus() also includes partially completed pieces.
+	CompletedLength string    `json:"completedLength"` // Completed length of this file in bytes. Please note that it is possible that sum of completedLength is less than the completedLength returned by the aria2.tellStatus() method. This is because completedLength in aria2.getFiles() only includes completed pieces. On the other hand, completedLength in aria2.tellStatus() also includes partially completed pieces.
 	Selected        string    `json:"selected"`  // true if this file is selected by --select-file option. If --select-file is not specified or this is single-file torrent or not a torrent download at all, this value is always true. Otherwise false.
 	URIs            []URIInfo `json:"uris"`      // Returns a list of URIs for this file. The element type is the same struct used in the aria2.getUris() method.
 }

--- a/rpc/resp.go
+++ b/rpc/resp.go
@@ -43,12 +43,12 @@ type URIInfo struct {
 
 // FileInfo represents an element of response of aria2.getFiles
 type FileInfo struct {
-	Index           string    `json:"index"`     // Index of the file, starting at 1, in the same order as files appear in the multi-file torrent.
-	Path            string    `json:"path"`      // File path.
-	Length          string    `json:"length"`    // File size in bytes.
+	Index           string    `json:"index"`           // Index of the file, starting at 1, in the same order as files appear in the multi-file torrent.
+	Path            string    `json:"path"`            // File path.
+	Length          string    `json:"length"`          // File size in bytes.
 	CompletedLength string    `json:"completedLength"` // Completed length of this file in bytes. Please note that it is possible that sum of completedLength is less than the completedLength returned by the aria2.tellStatus() method. This is because completedLength in aria2.getFiles() only includes completed pieces. On the other hand, completedLength in aria2.tellStatus() also includes partially completed pieces.
-	Selected        string    `json:"selected"`  // true if this file is selected by --select-file option. If --select-file is not specified or this is single-file torrent or not a torrent download at all, this value is always true. Otherwise false.
-	URIs            []URIInfo `json:"uris"`      // Returns a list of URIs for this file. The element type is the same struct used in the aria2.getUris() method.
+	Selected        string    `json:"selected"`        // true if this file is selected by --select-file option. If --select-file is not specified or this is single-file torrent or not a torrent download at all, this value is always true. Otherwise false.
+	URIs            []URIInfo `json:"uris"`            // Returns a list of URIs for this file. The element type is the same struct used in the aria2.getUris() method.
 }
 
 // PeerInfo represents an element of response of aria2.getPeers


### PR DESCRIPTION
Reference: https://aria2.github.io/manual/en/html/aria2c.html#aria2.getFiles
Should be `completedLength` instead of `completed`.